### PR TITLE
Use json error with OAuth2 standard

### DIFF
--- a/helpers/middleware.js
+++ b/helpers/middleware.js
@@ -10,7 +10,7 @@ const verifyPermissions = async (req, res, next) => {
 
   const userAccountAuths = accounts[1].posting.account_auths.map((account) => account[0]);
   if (userAccountAuths.indexOf(req.proxy) === -1) {
-    return res.status(400).json({
+    return res.status(401).json({
       error: 'unauthorized_client',
       error_description: `The app @${req.proxy} don't have permission to broadcast for @${req.user}`,
     });
@@ -18,7 +18,7 @@ const verifyPermissions = async (req, res, next) => {
 
   const appAccountAuths = accounts[0].posting.account_auths.map((account) => account[0]);
   if (appAccountAuths.indexOf(process.env.BROADCASTER_USERNAME) === -1) {
-    return res.status(400).json({
+    return res.status(401).json({
       error: 'unauthorized_client',
       error_description: `Broadcaster account don't have permission to broadcast for @${req.proxy}`,
     });
@@ -42,7 +42,7 @@ const strategy = (req, res, next) => {
 
 const authenticate = (role) => async (req, res, next) => {
   if (!req.role || (role && req.role !== role)) {
-    return res.status(400).json({
+    return res.status(401).json({
       error: 'invalid_grant',
       error_description: 'The access_token has invalid role',
     });
@@ -50,7 +50,7 @@ const authenticate = (role) => async (req, res, next) => {
   if (req.role === 'app') {
     const token = await tokens.findOne({ where: { token: req.token } });
     if (!token) {
-      return res.status(400).json({
+      return res.status(401).json({
         error: 'invalid_grant',
         error_description: 'The access_token has been revoked',
       });

--- a/helpers/middleware.js
+++ b/helpers/middleware.js
@@ -10,14 +10,18 @@ const verifyPermissions = async (req, res, next) => {
 
   const userAccountAuths = accounts[1].posting.account_auths.map((account) => account[0]);
   if (userAccountAuths.indexOf(req.proxy) === -1) {
-    console.log(`The app @${req.proxy} don't have permission to broadcast for @${req.user}.`);
-    return res.status(401).send('Unauthorized');
+    return res.status(400).json({
+      error: 'unauthorized_client',
+      error_description: `The app @${req.proxy} don't have permission to broadcast for @${req.user}`,
+    });
   }
 
   const appAccountAuths = accounts[0].posting.account_auths.map((account) => account[0]);
   if (appAccountAuths.indexOf(process.env.BROADCASTER_USERNAME) === -1) {
-    console.log(`Broadcaster account don't have permission to broadcast for @${req.proxy}.`);
-    return res.status(401).send('Unauthorized');
+    return res.status(400).json({
+      error: 'unauthorized_client',
+      error_description: `Broadcaster account don't have permission to broadcast for @${req.proxy}`,
+    });
   }
   next();
 };
@@ -38,12 +42,18 @@ const strategy = (req, res, next) => {
 
 const authenticate = (role) => async (req, res, next) => {
   if (!req.role || (role && req.role !== role)) {
-    return res.status(401).send('Unauthorized');
+    return res.status(400).json({
+      error: 'invalid_grant',
+      error_description: 'The access_token has invalid role',
+    });
   }
   if (req.role === 'app') {
     const token = await tokens.findOne({ where: { token: req.token } });
     if (!token) {
-      return res.status(401).send('Unauthorized');
+      return res.status(400).json({
+        error: 'invalid_grant',
+        error_description: 'The access_token has been revoked',
+      });
     }
   }
   next();

--- a/routes/api.js
+++ b/routes/api.js
@@ -44,7 +44,7 @@ router.put('/me', authenticate('app'), async (req, res, next) => {
         user_metadata,
       });
     } else {
-      return res.status(400).json({
+      return res.status(413).json({
         error: 'invalid_request',
         error_description: `User metadata object must not exceed ${config.user_metadata.max_size / 1000000} MB`,
       });
@@ -80,13 +80,13 @@ router.post('/broadcast', authenticate('app'), verifyPermissions, async (req, re
   });
 
   if (!scopeIsValid) {
-    return res.status(400).json({
+    return res.status(401).json({
       error: 'invalid_scope',
       error_description: `The operation ${operation[0]} is not allowed by the access_token scope`,
     });
   } else if (!requestIsValid) {
-    return res.status(400).json({
-      error: 'invalid_request',
+    return res.status(401).json({
+      error: 'unauthorized_client',
       error_description: `This access_token allow you to broadcast transaction only for the account @${req.user}`,
     });
   } else {
@@ -116,7 +116,7 @@ router.post('/broadcast', authenticate('app'), verifyPermissions, async (req, re
           res.json({ result });
         } else {
           debug('Transaction broadcast failed', operations, err);
-          return res.status(400).json({
+          return res.status(500).json({
             error: 'server_error',
             error_description: err.message || err,
           });


### PR DESCRIPTION
I've changed the error to use this OAuth2 standard (https://tools.ietf.org/html/rfc6749#section-5.2) example:
```
{
  error: 'invalid_request',
  error_description: 'The request is malformed',
}
```